### PR TITLE
Fixed bug : newline were not processed if no tags were present

### DIFF
--- a/test.js
+++ b/test.js
@@ -2,6 +2,11 @@
 const ava = require('ava');
 const yabbc = require('./ya-bbcode.js');
 
+let newlineTest = `[h1]Nodecraft[/h1]
+[b]Game Servers Done Right[/b]`;
+let newlineNoTagTest = `Nodecraft
+Game Servers Done Right`;
+
 let bbcodes = {
 	'none': 'Nodecraft Game servers',
 	'invalid': '[Nodecraft]Game servers[/nodecraft]',
@@ -35,10 +40,10 @@ let bbcodes = {
 	'img_invalid': '[img][/img]',
 	'noparse': '[noparse][img]https://nodecraft.com/assets/images/logo.png[/img][/noparse]',
 	'noparse_nested': '[noparse][url=https://nodecraft.com][img]https://nodecraft.com/assets/images/logo.png[/img][/url][/noparse]',
-	'noparse_unclosed': '[noparse][img]https://nodecraft.com/assets/images/logo.png[/img]'
+	'noparse_unclosed': '[noparse][img]https://nodecraft.com/assets/images/logo.png[/img]',
+	'newline': newlineTest,
+	'newline_notag': newlineNoTagTest
 };
-let newlineTest = `[h1]Nodecraft[/h1]
-[b]Game Servers Done Right[/b]`;
 
 ava('Bad yabbc instance', (t) => {
 	t.is(yabbc().parse(bbcodes.none), bbcodes.none);
@@ -214,11 +219,15 @@ ava('Custom Tag: Invalid Type', (t) => {
 });
 ava('New line: converted', (t) => {
 	let parser = new yabbc({newline: true});
-	t.is(parser.parse(newlineTest), '<h1>Nodecraft</h1><br/><strong>Game Servers Done Right</strong>');
+	t.is(parser.parse(bbcodes.newline), '<h1>Nodecraft</h1><br/><strong>Game Servers Done Right</strong>');
 });
 ava('New line: retained', (t) => {
 	let parser = new yabbc({newline: false});
-	t.is(parser.parse(newlineTest), '<h1>Nodecraft</h1>\n<strong>Game Servers Done Right</strong>');
+	t.is(parser.parse(bbcodes.newline), '<h1>Nodecraft</h1>\n<strong>Game Servers Done Right</strong>');
+});
+ava('New line: converted with no tag', (t) => {
+	let parser = new yabbc({newline: true});
+	t.is(parser.parse(bbcodes.newline_notag), 'Nodecraft<br/>Game Servers Done Right');
 });
 ava('Clean unmatchable: cleaned', (t) => {
 	let parser = new yabbc({cleanUnmatchable: true});

--- a/test.js
+++ b/test.js
@@ -229,6 +229,10 @@ ava('New line: converted with no tag', (t) => {
 	let parser = new yabbc({newline: true});
 	t.is(parser.parse(bbcodes.newline_notag), 'Nodecraft<br/>Game Servers Done Right');
 });
+ava('Paragraph: enabled', (t) => {
+	let parser = new yabbc({newline: true, paragraph: true});
+	t.is(parser.parse(bbcodes.newline), '<p><h1>Nodecraft</h1></p><p><strong>Game Servers Done Right</strong></p>');
+});
 ava('Clean unmatchable: cleaned', (t) => {
 	let parser = new yabbc({cleanUnmatchable: true});
 	t.is(parser.parse(bbcodes.unmatchable), '<strong>Game Servers Done Right!</strong>');

--- a/ya-bbcode.js
+++ b/ya-bbcode.js
@@ -7,10 +7,14 @@ const yabbcode = function(config = {}){
 	let self = this;
 	this.config = {
 		newline: true,
+		paragraph: false,
 		cleanUnmatchable: true
 	};
 	if(config.newline !== undefined){
 		this.config.newline = config.newline;
+	}
+	if(config.paragraph !== undefined){
+		this.config.paragraph = config.paragraph;
 	}
 	if(config.cleanUnmatchable !== undefined){
 		this.config.cleanUnmatchable = config.cleanUnmatchable;
@@ -293,12 +297,19 @@ yabbcode.prototype.parse = function(bbcInput){
 	let tags = String(input).match(this.regex.tags);
 
 	if(this.config.newline){
-		input = input.replace(this.regex.newline, "</p><p>");
+		if(this.config.paragraph){
+			input = input.replace(this.regex.newline, "</p><p>");
+		}else{
+			input = input.replace(this.regex.newline, "<br/>");
+		}
+	}
+	if(this.config.paragraph){
+		input = '<p>' + input + '</p>';
 	}
 
 	// handle when no tags are present
 	if(!tags || !tags.length){
-		return '<p>' + input + '</p>';
+		return input;
 	}
 	tags.forEach((tag, i) => {
 		let parts = tag.slice(1, -1).split('=');
@@ -327,7 +338,7 @@ yabbcode.prototype.parse = function(bbcInput){
 	if(this.config.cleanUnmatchable){
 		input = input.replace(this.regex.placeholders, '');
 	}
-	return '<p>' + input + '</p>';
+	return input;
 };
 
 module.exports = yabbcode;

--- a/ya-bbcode.js
+++ b/ya-bbcode.js
@@ -292,6 +292,10 @@ yabbcode.prototype.parse = function(bbcInput){
 	// split input into tags by index
 	let tags = String(input).match(this.regex.tags);
 
+	if(this.config.newline){
+		input = input.replace(this.regex.newline, "<br/>");
+	}
+
 	// handle when no tags are present
 	if(!tags || !tags.length){
 		return input;
@@ -320,9 +324,6 @@ yabbcode.prototype.parse = function(bbcInput){
 	tagsMap = this._tagLoop(tagsMap);
 	// put back all non-found matches?
 	input = this._contentLoop(tagsMap, input);
-	if(this.config.newline){
-		input = input.replace(this.regex.newline, "<br/>");
-	}
 	if(this.config.cleanUnmatchable){
 		input = input.replace(this.regex.placeholders, '');
 	}

--- a/ya-bbcode.js
+++ b/ya-bbcode.js
@@ -293,12 +293,12 @@ yabbcode.prototype.parse = function(bbcInput){
 	let tags = String(input).match(this.regex.tags);
 
 	if(this.config.newline){
-		input = input.replace(this.regex.newline, "<br/>");
+		input = input.replace(this.regex.newline, "</p><p>");
 	}
 
 	// handle when no tags are present
 	if(!tags || !tags.length){
-		return input;
+		return '<p>' + input + '</p>';
 	}
 	tags.forEach((tag, i) => {
 		let parts = tag.slice(1, -1).split('=');
@@ -327,7 +327,7 @@ yabbcode.prototype.parse = function(bbcInput){
 	if(this.config.cleanUnmatchable){
 		input = input.replace(this.regex.placeholders, '');
 	}
-	return input;
+	return '<p>' + input + '</p>';
 };
 
 module.exports = yabbcode;


### PR DESCRIPTION
There was a bug when processing text with no bbcode tag in it :

`I'm a line !
[b]I'm another line ![/b]`

would render to `I'm a line<br/><strong>I'm another line !</strong>`
but
`I'm a line !
I'm another line !`
would not render the `<br/>` tag, which I don't think is the expected behaviour ?

Nice project btw, keep up the good work :) 