### PR TITLE
Fixes issue with tags nested inside a noparse block.

### DIFF
--- a/test.js
+++ b/test.js
@@ -139,7 +139,7 @@ ava('Tag: noparse', (t) => {
 	let parser = new yabbc();
 	t.is(parser.parse(bbcodes.noparse), '[img]https://nodecraft.com/assets/images/logo.png[/img]');
 });
-ava.skip('Tag: noparse nested', (t) => {
+ava('Tag: noparse nested', (t) => {
 	let parser = new yabbc();
 	t.is(parser.parse(bbcodes.noparse_nested), '[url=https://nodecraft.com][img]https://nodecraft.com/assets/images/logo.png[/img][/url]');
 });

--- a/ya-bbcode.js
+++ b/ya-bbcode.js
@@ -190,7 +190,7 @@ yabbcode.prototype._ignoreLoop = function(tagsMap, content){
 			content = content.replace('[TAG-' + tag.closing.index + ']', tag.closing.raw);
 		}
 		if(tag.children.length){
-			this._ignoreLoop(tag.children, content);
+			content = this._ignoreLoop(tag.children, content);
 		}
 	});
 	return content;


### PR DESCRIPTION
This was a pretty easy fix, content was not being passed back out of the recursive call to _ignoreLoop